### PR TITLE
Implement the full quiz functionality without requiring any JavaScript to run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,36 +19,41 @@ The plugin is made for Wordpress, but the JavaScript component can easily be imp
 
 If you're using a different content management system, you can still use the JavaScript component to enable this functionality on your site.
 
-The component requires a `DIV` right before the container which holds your comment form. The `DIV` has two data-attributes: `data-nrkbetaquiz` and `data-nrkbetaquiz-error`. The `DIV` also needs the class `nrkbetaquiz`.
+The component requires a `DIV` to be inserted as a direct child of your comment form. The `DIV` has three `data-`attributes: `data-nrkbetaquiz`, `data-nrkbetaquiz-error`, and `data-nrkbetaquiz-correct`. The `DIV` also needs the class `nrkbetaquiz`.
 
-`data-nrkbetaquiz-error` is a string with the error message in case the user has answered the quiz wrongfully.
-`data-nrkbetaquiz` is an array with the following structure:
+* `data-nrkbetaquiz-error` is a string with the error message in case the user has answered the quiz wrongfully.
+* `data-nrkbetaquiz-correct` is a string with the success message when the user answers the quiz correctly.
+* `data-nrkbetaquiz` is a [JSON](http://json.org/) array with the following structure:  
 
-	[{
-	    text: 'Who is the current president of The Unites States?'
-	    answers: ['Barack Obama', 'Donald Trump', 'Steve Bannon'],
-	    correct: 1
-	  }, {
-	    text: 'What is the radius of Earth?'
-	    answers: ['6 371 kilometers', '371 kilometers', '200 kilometers'],
-	    correct: 0
-	}]
-
+  ```json
+  [{
+      "text": "Who is the current president of The Unites States?",
+      "answers": ["Barack Obama", "Donald Trump", "Steve Bannon"],
+      "correct": 1
+    }, {
+      "text": "What is the radius of Earth?",
+      "answers": ["6,371 kilometers", "371 kilometers", "200 kilometers"],
+      "correct": 0
+  }]
+  ```
 
 Here's a full example of the implementation:
 
-	<script src="nrkbetaquiz.js"></script>
-	<div class="nrkbetaquiz"
-	  data-nrkbetaquiz="[{
-	      text: 'Who is the current president of The Unites States?'
-	      answers: ['Barack Obama', 'Donald Trump', 'Steve Bannon'],
-	      correct: 1
-	    }, {
-	      text: 'What is the radius of Earth?'
-	      answers: ['6 371 kilometers', '371 kilometers', '200 kilometers'],
-	      correct: 0
-	  }]"
-	  data-nrkbetaquiz-error="You fail">
-	</div>
-
-	<div id="YOUR_COMMENT_FORM_CONTAINER"></div>
+```html
+<form id="YOUR_COMMENT_FORM_CONTAINER">
+    <script src="nrkbetaquiz.js"></script>
+    <div class="nrkbetaquiz"
+        data-nrkbetaquiz='[{
+                "text": "Who is the current president of The Unites States?",
+                "answers": ["Barack Obama", "Donald Trump", "Steve Bannon"],
+                "correct": 1
+            }, {
+                "text": "What is the radius of Earth?",
+                "answers": ["6,371 kilometers", "371 kilometers", "200 kilometers"],
+                "correct": 0
+            }]'
+        data-nrkbetaquiz-error="You fail"
+        data-nrkbetaquiz-correct="You succeed"
+    ></div>
+</form>
+```

--- a/nrkbetaquiz.css
+++ b/nrkbetaquiz.css
@@ -1,27 +1,27 @@
-.nrkbetaquiz,
-.nrkbetaquiz + * {
-  overflow: hidden;
-  transition: .5s;
-  height: 0;
-}
-.nrkbetaquiz { height: auto }
-.nrkbetaquiz label {
-  cursor: pointer;
-  display: inline-block;
-  margin: 0 7px 6px 0;
-  border-radius: 5px;
-  padding: 10px 15px;
-  background: #eee;
-  transition: .2s;
+.nrkbetaquiz label.answer {
+    cursor: pointer;
+    display: inline-block;
+    margin: 0 7px 6px 0;
+    border-radius: 5px;
+    padding: 10px 15px;
+    background: #eee;
 }
 .nrkbetaquiz label:hover {
-  background: #ccc;
+    background: #ccc;
 }
-.nrkbetaquiz h3 {
-  color: red;
-  font: inherit;
-  animation: nrkbetaquiz forward;
+.nrkbetaquiz p.correct,
+.nrkbetaquiz p.error {
+    font: inherit;
+    animation: .5s nrkbetaquiz;
 }
-@keyframes nrkbetaquiz{
-  from{transform:scale(0)}
+.nrkbetaquiz p.correct {
+    color: green;
+    font-weight: bold;
+}
+.nrkbetaquiz p.error {
+    color: red;
+}
+@keyframes nrkbetaquiz {
+    from { transform: scale(0); }
+    to { transform: scale(1); }
 }

--- a/nrkbetaquiz.php
+++ b/nrkbetaquiz.php
@@ -147,7 +147,7 @@ function nrkbetaquiz_pre_comment_on_post( $post_id ) {
 
     $answers = array_intersect_key( $_POST, $correct_answers );
     $permalink = get_permalink( $post_id );
-    if ( array_diff( $answers, $correct_answers ) ) {
+    if ( ( count( $answers ) !== count( $correct_answers ) ) || array_diff( $answers, $correct_answers ) ) {
         // The user did not answer all quiz question(s) correctly.
         $redirect = $permalink;
         $redirect .= '?' . rawurlencode( NRKBCQ . '_quiz_error' ) . '=1';

--- a/nrkbetaquiz.php
+++ b/nrkbetaquiz.php
@@ -18,7 +18,7 @@ add_action('wp_enqueue_scripts', function(){
 add_action('comment_form_before', 'nrkbetaquiz_form');
 function nrkbetaquiz_form(){ ?>
   <div class="<?php echo NRKBCQ; ?>"
-    data-<?php echo NRKBCQ; ?>="<?php echo esc_attr(urlencode(json_encode(get_post_meta(get_the_ID(), NRKBCQ)))); ?>"
+    data-<?php echo NRKBCQ; ?>="<?php echo esc_attr(rawurlencode(json_encode(get_post_meta(get_the_ID(), NRKBCQ)))); ?>"
     data-<?php echo NRKBCQ; ?>-error="<?php echo esc_attr(__('You have not answered the quiz correctly. Try again.', NRKBCQ)); ?>">
     <h2>Would you like to comment? Please answer some quiz questions from the story.</h2>
     <p>

--- a/nrkbetaquiz.php
+++ b/nrkbetaquiz.php
@@ -60,11 +60,14 @@ function nrkbetaquiz_form_top() {
     global $post;
     if ( nrkbetaquiz_post_has_quiz( $post ) ) {
         $quiz = get_post_meta( $post->ID, NRKBCQ );
-        // TODO: Remove this CSS once JS-dependant quiz is not needed.
-        echo '<style>#respond { height: auto; }</style>';
 ?>
     <noscript>
-        <?php if ( isset( $_GET[ NRKBCQ . '_quiz_error' ] ) ) { ?>
+        <?php
+        // TODO: Remove this CSS once JS-dependant quiz is not needed.
+        echo '<style>#respond { height: auto; }</style>';
+
+        if ( isset( $_GET[ NRKBCQ . '_quiz_error' ] ) ) {
+        ?>
             <p class="error"><?php esc_html_e( 'You have not answered the quiz correctly. Try again.', 'nrkbetaquiz' ); ?></p>
         <?php
         }

--- a/nrkbetaquiz.php
+++ b/nrkbetaquiz.php
@@ -160,39 +160,22 @@ add_action( 'add_meta_boxes', 'nrkbetaquiz_add' );
  * @link https://developer.wordpress.org/reference/hooks/add_meta_boxes/
  */
 function nrkbetaquiz_add() {
-  add_meta_box( NRKBCQ, 'CommentQuiz', 'nrkbetaquiz_edit', 'post', 'side', 'high' );
+  add_meta_box( NRKBCQ, __('Comment Quiz', 'nrkbetaquiz'), 'nrkbetaquiz_edit', 'post', 'side', 'high' );
 }
 
 /**
  * Prints the quiz's Meta Box when editing a post.
  *
  * @param WP_Post $post
+ *
+ * @uses print_quiz_question_edit_html
  */
-function nrkbetaquiz_edit($post){
-  $questions = array_pad(get_post_meta($post->ID, NRKBCQ), 1, array());
-  $addmore = esc_html(__('Add question +', 'nrkbetaquiz'));
-  $correct = esc_html(__('Correct', 'nrkbetaquiz'));
-  $answer = esc_attr(__('Answer', 'nrkbetaquiz'));
-
-  foreach($questions as $index => $question){
-    $title = __('Question', 'nrkbetaquiz') . ' ' . ($index + 1);
-    $text = esc_attr(empty($question['text'])? '' : $question['text']);
-    $name = NRKBCQ . '[' . $index . ']';
-
-    echo '<div style="margin-bottom:1em;padding-bottom:1em;border-bottom:1px solid #eee">';
-    echo '<label><strong>' . esc_html($title) . ':</strong><br><input type="text" name="' . esc_attr($name) . '[text]" value="' . esc_attr($text) . '"></label>';
-    for($i = 0; $i<3; $i++){
-      $check = checked($i, isset($question['correct'])? intval($question['correct']) : 0, false);
-      $value = isset($question['answer'][$i])? esc_attr($question['answer'][$i]) : '';
-
-      echo '<br><input type="text" name="' . esc_attr($name) . '[answer][' . esc_attr($i) . ']" placeholder="' . esc_attr($answer) . '" value="' . esc_attr($value) . '">';
-      echo '<label><input type="radio" name="' . esc_attr($name) . '[correct]" value="' . esc_attr($i) . '"' .$check . '> ' . esc_html($correct) . '</label>';
-    }
-    echo '</div>';
-  }
-  echo '<button class="button" type="button" data-' . esc_attr(NRKBCQ) . '>' . esc_html($addmore) . '</button>';
-
-  ?><script>
+function nrkbetaquiz_edit( $post ) {
+    nrkbetaquiz_print_quiz_question_edit_html( $post );
+    $addmore = esc_html( __( 'Add question +', 'nrkbetaquiz' ) );
+    echo '<button class="button hide-if-no-js" type="button" data-' . esc_attr( NRKBCQ ) . '>' . esc_html( $addmore ) . '</button>';
+?><script>
+    // Add another question to the quiz editing form.
     document.addEventListener('click', function(event){
       if(event.target.hasAttribute('data-<?php echo esc_js(esc_attr(NRKBCQ)); ?>')){
         var button = event.target;
@@ -209,7 +192,42 @@ function nrkbetaquiz_edit($post){
       }
     });
   </script>
-  <?php wp_nonce_field(NRKBCQ, NRKBCQ_NONCE);
+  <?php wp_nonce_field( NRKBCQ, NRKBCQ_NONCE );
+}
+
+/**
+ * Prints the HTML for a quiz question in the edit form.
+ *
+ * @param WP_Post $post
+ */
+function nrkbetaquiz_print_quiz_question_edit_html ( $post ) {
+    $quiz = get_post_meta( $post->ID, NRKBCQ );
+    $questions = array_pad( $quiz, count($quiz) + 1, array() );
+
+    $answer = esc_attr( __( 'Answer', 'nrkbetaquiz' ) );
+    $ask = esc_attr( __( 'Question', 'nrkbetaquiz' ) );
+    $correct = esc_html( __( 'Correct', 'nrkbetaquiz' ) );
+
+    foreach( $questions as $index => $question ) {
+        $title = __( 'Question', 'nrkbetaquiz' ) . ' ' . ( $index + 1 );
+        $text = esc_attr( empty( $question[ 'text' ] ) ? '' : $question[ 'text' ] );
+        $name = NRKBCQ . '[' . $index . ']';
+
+        echo '<div style="margin-bottom:1em;padding-bottom:1em;border-bottom:1px solid #eee">';
+        echo '<p><label><strong style="display:block;">' . esc_html( $title ) . ':</strong><input type="text" name="' . esc_attr( $name ) . '[text]" placeholder="' . esc_attr( $ask ) . '" value="' . esc_attr( $text ) . '"></label></p>';
+        echo '<ul>';
+        for( $i = 0; $i < 3; $i++ ) {
+            $check = checked( $i, isset( $question[ 'correct' ] ) ? intval( $question[ 'correct' ] ) : 0, false );
+            $value = isset( $question[ 'answer' ][ $i ] ) ? esc_attr( $question[ 'answer' ][ $i ] ) : '';
+
+            echo '<li>';
+            echo '<input type="text" name="' . esc_attr( $name ) . '[answer][' . esc_attr( $i ) . ']" placeholder="' . esc_attr( $answer ) . '" value="' . esc_attr( $value ) . '">';
+            echo '<label><input type="radio" name="' . esc_attr( $name ) . '[correct]" value="' . esc_attr( $i ) . '"' .$check . '> ' . esc_html( $correct ) . '</label>';
+            echo '</li>';
+        }
+        echo '</ul>';
+        echo '</div>';
+    }
 }
 
 add_action('save_post', 'nrkbetaquiz_save', 10, 3);

--- a/nrkbetaquiz.php
+++ b/nrkbetaquiz.php
@@ -1,11 +1,21 @@
 <?php
-/*
-Plugin Name: NRKBeta Know2Comment
-Version: 1.0.0
-Plugin URI: https://nrkbeta.no/
-Author: Henrik Lied and Eirik Backer, Norwegian Broadcasting Corporation
-Description: Require the user to answer a quiz to be able to post comments.
-*/
+/**
+ * Know2Comment plugin for WordPress.
+ *
+ * WordPress plugin header information:
+ *
+ * * Plugin Name: NRKBeta Know2Comment
+ * * Plugin URI: https://nrkbeta.no/
+ * * Version: 1.0.0
+ * * Description: Require the user to answer a quiz to be able to post comments.
+ * * Author: Henrik Lied and Eirik Backer, Norwegian Broadcasting Corporation
+ * * Text Domain: nrkbetaquiz
+ * * Domain Path: /languages
+ *
+ * @link https://developer.wordpress.org/plugins/the-basics/header-requirements/
+ *
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 
 define('NRKBCQ', 'nrkbetaquiz');
 define('NRKBCQ_NONCE', NRKBCQ . '-nonce');
@@ -17,16 +27,16 @@ add_action('wp_enqueue_scripts', function(){
 
 add_action('comment_form_before', 'nrkbetaquiz_form');
 function nrkbetaquiz_form(){ ?>
-  <div class="<?php echo NRKBCQ; ?>"
-    data-<?php echo NRKBCQ; ?>="<?php echo esc_attr(urlencode(json_encode(get_post_meta(get_the_ID(), NRKBCQ)))); ?>"
-    data-<?php echo NRKBCQ; ?>-error="<?php echo esc_attr(__('You have not answered the quiz correctly. Try again.', NRKBCQ)); ?>">
-    <h2>Would you like to comment? Please answer some quiz questions from the story.</h2>
-    <p>
+  <div class="<?php esc_attr_e(NRKBCQ); ?>"
+    data-<?php esc_attr_e(NRKBCQ); ?>="<?php echo esc_attr(urlencode(json_encode(get_post_meta(get_the_ID(), 'nrkbetaquiz')))); ?>"
+    data-<?php esc_attr_e(NRKBCQ); ?>-error="<?php esc_attr_e('You have not answered the quiz correctly. Try again.', 'nrkbetaquiz'); ?>">
+    <h2><?php esc_html_e('Would you like to comment? Please answer some quiz questions from the story.', 'nrkbetaquiz');?></h2>
+    <p><?php esc_html_e("
       We care about our comments.
       That's why we want to make sure that everyone who comments have actually read the story.
       Answer a couple of questions from the story to unlock the comment form.
-    </p>
-    <noscript>Please <a href="http://enable-javascript.com/" target="_blank" style="text-decoration:underline">enable javascript</a> to comment</noscript>
+    ", 'nrkbetaquiz');?></p>
+    <noscript><?php _e(sprintf(esc_html('Please %1$senable javascript%2$s to comment'), '<a href="http://enable-javascript.com/" target="_blank" style="text-decoration:underline">', '</a>'), 'nrkbetaquiz');?></noscript>
   </div>
 <?php }
 
@@ -37,31 +47,31 @@ function nrkbetaquiz_add(){
 
 function nrkbetaquiz_edit($post){
   $questions = array_pad(get_post_meta($post->ID, NRKBCQ), 1, array());
-  $addmore = esc_html(__('Add question +', NRKBCQ));
-  $correct = esc_html(__('Correct', NRKBCQ));
-  $answer = esc_attr(__('Answer', NRKBCQ));
+  $addmore = esc_html(__('Add question +', 'nrkbetaquiz'));
+  $correct = esc_html(__('Correct', 'nrkbetaquiz'));
+  $answer = esc_attr(__('Answer', 'nrkbetaquiz'));
 
   foreach($questions as $index => $question){
-    $title = __('Question', NRKBCQ) . ' ' . ($index + 1);
+    $title = __('Question', 'nrkbetaquiz') . ' ' . ($index + 1);
     $text = esc_attr(empty($question['text'])? '' : $question['text']);
     $name = NRKBCQ . '[' . $index . ']';
 
     echo '<div style="margin-bottom:1em;padding-bottom:1em;border-bottom:1px solid #eee">';
-    echo '<label><strong>' . $title . ':</strong><br><input type="text" name="' . $name . '[text]" value="' . $text . '"></label>';
+    echo '<label><strong>' . esc_html($title) . ':</strong><br><input type="text" name="' . esc_attr($name) . '[text]" value="' . esc_attr($text) . '"></label>';
     for($i = 0; $i<3; $i++){
       $check = checked($i, isset($question['correct'])? intval($question['correct']) : 0, false);
       $value = isset($question['answer'][$i])? esc_attr($question['answer'][$i]) : '';
 
-      echo '<br><input type="text" name="' . $name . '[answer][' . $i . ']" placeholder="' . $answer . '" value="' . $value . '">';
-      echo '<label><input type="radio" name="' . $name . '[correct]" value="' . $i . '"' . $check . '> ' . $correct . '</label>';
+      echo '<br><input type="text" name="' . esc_attr($name) . '[answer][' . esc_attr($i) . ']" placeholder="' . esc_attr($answer) . '" value="' . esc_attr($value) . '">';
+      echo '<label><input type="radio" name="' . esc_attr($name) . '[correct]" value="' . esc_attr($i) . '"' .$check . '> ' . esc_html($correct) . '</label>';
     }
     echo '</div>';
   }
-  echo '<button class="button" type="button" data-' . NRKBCQ . '>' . $addmore . '</button>';
+  echo '<button class="button" type="button" data-' . esc_attr(NRKBCQ) . '>' . esc_html($addmore) . '</button>';
 
   ?><script>
     document.addEventListener('click', function(event){
-      if(event.target.hasAttribute('data-<?php echo NRKBCQ; ?>')){
+      if(event.target.hasAttribute('data-<?php echo esc_js(esc_attr(NRKBCQ)); ?>')){
         var button = event.target;
         var index = [].indexOf.call(button.parentNode.children, button);
         var clone = button.previousElementSibling.cloneNode(true);


### PR DESCRIPTION
I absolutely love the idea of this plugin! That said, while I am admittedly not the typical end-user, I dislike needing JavaScript to access basic functionality on a website, and I usually surf the Web with JavaScript completely disabled.

To that end, I have implemented your quiz functionality in its entirety for a reader of a WordPress blog using your plugin who does not have JavaScript enabled. All features work, including randomized positions of the quiz answers, displaying the "Try again" message, remembering prior quiz answers (using an HTTP-only cookie that checks a SHA-256 hash of the serialized quiz data), and retaining comment content across page loads.

I have also obsessively filtered all string output through WordPress's `esc_*` functions and added PHP DocBlocks, which was mostly for my own benefit as I was familiarizing myself with your plugin.

The same has been done for blog authors, so that the admin-side portion of this plugin does not require JavaScript to function. Previously, JavaScript is needed to add more than one question to a post's quiz.

Finally, prior to this PR, while the comment form was hidden from human users who were browsing with CSS enabled, it was still possible to post comments without actually answering the comment quiz. The comment form was also shown, and active, to visitors using text-only or console-based browsers. These users (or, more likely, spam bots) could simply ignore the comment quiz, since their answers were never checked. With this pull request, the server actually verifies that a user has answered all questions in the quiz correctly, and does not process the comment further if any answer is wrong.

Thanks for offering this wonderful plugin idea.