### PR TITLE
Fixes #4: Use `rawurlencode()` so that spaces become `%20`, not `+`.

### DIFF
--- a/nrkbetaquiz.php
+++ b/nrkbetaquiz.php
@@ -18,7 +18,7 @@ add_action('wp_enqueue_scripts', function(){
 add_action('comment_form_before', 'nrkbetaquiz_form');
 function nrkbetaquiz_form(){ ?>
   <div class="<?php echo NRKBCQ; ?>"
-    data-<?php echo NRKBCQ; ?>="<?php echo esc_attr(urlencode(json_encode(get_post_meta(get_the_ID(), NRKBCQ)))); ?>"
+    data-<?php echo NRKBCQ; ?>="<?php echo esc_attr(rawurlencode(json_encode(get_post_meta(get_the_ID(), NRKBCQ)))); ?>"
     data-<?php echo NRKBCQ; ?>-error="<?php echo esc_attr(__('You have not answered the quiz correctly. Try again.', NRKBCQ)); ?>">
     <h2>Would you like to comment? Please answer some quiz questions from the story.</h2>
     <p>


### PR DESCRIPTION
This commit fixes the issue where quiz questions and answers with spaces in them show up with a `+` instead of spaces.

This commit is *included* in #6, so if you are comfortable merging that pull request this one can be immediately closed in favor of the other.